### PR TITLE
Fix conflicting commands

### DIFF
--- a/lua/ulx/modules/sh/mapvote.lua
+++ b/lua/ulx/modules/sh/mapvote.lua
@@ -10,9 +10,9 @@ local function AMB_mapvote( calling_ply, votetime, should_cancel )
 	end
 end
 
-local mapvotecmd = ulx.command( CATEGORY_NAME, "mapvote", AMB_mapvote, "!mapvote" )
+local mapvotecmd = ulx.command( CATEGORY_NAME, "forcemapvote", AMB_mapvote, "!forcemapvote" )
 mapvotecmd:addParam{ type = ULib.cmds.NumArg, min = 15, default = 25, hint = "time", ULib.cmds.optional, ULib.cmds.round }
 mapvotecmd:addParam{ type = ULib.cmds.BoolArg, invisible = true }
 mapvotecmd:defaultAccess( ULib.ACCESS_ADMIN )
 mapvotecmd:help( "Invokes the map vote logic" )
-mapvotecmd:setOpposite( "unmapvote", { _, _, true }, "!unmapvote" )
+mapvotecmd:setOpposite( "forceunmapvote", { _, _, true }, "!forceunmapvote" )


### PR DESCRIPTION
There was already a !mapvote command, so we accidentally had an admin force a mapvote when they were just trying to cast their vote 😬 