### PR TITLE
Fix vote progressing with 0 counted players

### DIFF
--- a/lua/mapvote/server/modules/rtv.lua
+++ b/lua/mapvote/server/modules/rtv.lua
@@ -66,6 +66,7 @@ function RTV.ShouldChange()
     if plyCount < conf.RTVPlayerCount then return end
     local totalVotes = RTV.GetVoteCount()
     local totalPlayers = RTV.GetPlayerCount()
+    if totalPlayers == 0 then return end
     return totalVotes >= math.Round( totalPlayers * conf.RTVPercentPlayersRequired )
 end
 


### PR DESCRIPTION
In a situation where there are zero total counted players, I assume the map change should not progress.

This can happen if all players are afk, for example.
