### PR TITLE
Use math.ceil instead of math.Round

### DIFF
--- a/lua/mapvote/client/modules/map_vote.lua
+++ b/lua/mapvote/client/modules/map_vote.lua
@@ -72,7 +72,7 @@ function MapVote.StartVote( maps, endTime )
             timer.Remove( "MapVoteCountdown" )
             return
         end
-        local timeLeft = math.Round( math.Clamp( endTime - CurTime(), 0, math.huge ) )
+        local timeLeft = math.ceil( math.Clamp( endTime - CurTime(), 0, math.huge ) )
 
         countdownLabel:SetText( string.FormattedTime( timeLeft or 0, "%02i:%02i" ) )
     end )

--- a/lua/mapvote/server/modules/rtv.lua
+++ b/lua/mapvote/server/modules/rtv.lua
@@ -69,7 +69,7 @@ function RTV.ShouldChange()
 
     if totalPlayers == 0 then return end
 
-    return totalVotes >= math.Round( totalPlayers * conf.RTVPercentPlayersRequired )
+    return totalVotes >= math.ceil( totalPlayers * conf.RTVPercentPlayersRequired )
 end
 
 function RTV.StartIfShouldChange()
@@ -99,7 +99,7 @@ function RTV.AddVote( ply )
     timer.Simple( 0, function()
         if not ply:IsValid() then return end
         MsgN( ply:Nick() .. " has voted to change the map." )
-        local percentage = math.Round( RTV.GetPlayerCount() * conf.RTVPercentPlayersRequired )
+        local percentage = math.ceil( RTV.GetPlayerCount() * conf.RTVPercentPlayersRequired )
         PrintMessage( HUD_PRINTTALK,
             ply:Nick() .. " has voted to change the map. (" .. RTV.GetVoteCount() .. "/" .. percentage .. ")" )
     end )
@@ -127,7 +127,7 @@ function RTV.CanVote( ply )
     if ply.RTVVoted then
         return false,
             string.format( "You have already voted to change the map! (%s/%s)", RTV.GetVoteCount(),
-                math.Round( RTV.GetPlayerCount() * conf.RTVPercentPlayersRequired ) )
+                math.ceil( RTV.GetPlayerCount() * conf.RTVPercentPlayersRequired ) )
     end
 
     if MapVote.state.isInProgress then


### PR DESCRIPTION
I think that math.ceil handles edge cases like 1-2 players a lot better than math.Round.
For example when there are 2 players you probably don't want the map vote to trigger when just 1 votes to change the map. So you either have to:
a) Set percentage of players who need to RTV to 0.75+
b) Set minimum players to enable RTVing to 3+
Both of these options can be undesirable because:
a) Players are sloths and it can be hard to get 75% to RTV when there are more people on
b) It completely blocks map changing when there are <2 players on the server, which can be frustrating
Also consider that math.ceil behaves exactly the same as if no rounding is done at all, which makes more sense for me