### PR TITLE
Make recent maps use a function instead of halting hook

### DIFF
--- a/lua/mapvote/server/modules/map_vote.lua
+++ b/lua/mapvote/server/modules/map_vote.lua
@@ -4,6 +4,7 @@ function MapVote.isMapAllowed( m )
     local hookResult = hook.Run( "MapVote_IsMapAllowed", m )
     if hookResult ~= nil then return hookResult end
 
+    if MapVote.wasMapRecentlyPlayed( m ) then return false end -- dont allow recently played maps in vote
     if not conf.AllowCurrentMap and m == game.GetMap():lower() then return false end -- dont allow current map in vote
 
     if conf.MapConfig and conf.MapConfig[m] then

--- a/lua/mapvote/server/modules/recent_maps.lua
+++ b/lua/mapvote/server/modules/recent_maps.lua
@@ -1,4 +1,4 @@
-hook.Add( "MapVote_IsMapAllowed", "MapVote_CheckRecentMaps", function( map )
+function MapVote.wasMapRecentlyPlayed( map )
     local conf = MapVote.GetConfig()
 
     if MapVote.config.EnableCooldown ~= true then return end
@@ -10,8 +10,8 @@ hook.Add( "MapVote_IsMapAllowed", "MapVote_CheckRecentMaps", function( map )
         end
     end
 
-    if MapVote.recentMaps[map] then return false end
-end )
+    if MapVote.recentMaps[map] then return true end
+end
 
 hook.Add( "Initialize", "MapVote_UpdateDB", function()
     MapVote.DB.MapPlayed( game.GetMap() )


### PR DESCRIPTION
Fixes the issue of
```lua
    hook.Add( "MapVote_IsMapAllowed", "AllowCurrentMap", function( map )
        if game.GetMap():lower() == map then return true end
    end )
```
currently not working as the `MapVote_CheckRecentMaps` was previously breaking the hook order.