### PR TITLE
Only use one map download table

### DIFF
--- a/lua/mapvote/client/modules/thumb_downloader.lua
+++ b/lua/mapvote/client/modules/thumb_downloader.lua
@@ -66,7 +66,15 @@ end
 function ThumbDownloader:RequestWorkshopIDs()
     if #self.mapsToDownload == 0 then return end
 
-    MapVote.Net.requestWorskhopIDs( self.mapsToDownload )
+    local mapsNeedingIDs = {}
+    for _, mapData in pairs( self.mapsToDownload ) do
+        local map = mapData.map
+        if not self.workshopIDLookup[map] and not self.urlOverrides[map] then
+            table.insert( mapsNeedingIDs, map )
+        end
+    end
+
+    MapVote.Net.requestWorskhopIDs( mapsNeedingIDs )
 end
 
 function ThumbDownloader:DownloadAll()

--- a/lua/mapvote/client/modules/thumb_downloader.lua
+++ b/lua/mapvote/client/modules/thumb_downloader.lua
@@ -69,7 +69,7 @@ function ThumbDownloader:RequestWorkshopIDs()
     local mapsNeedingIDs = {}
     for _, mapData in pairs( self.mapsToDownload ) do
         local map = mapData.map
-        if not self.workshopIDLookup[map] and not self.urlOverrides[map] then
+        if not self.urlOverrides[map] then
             table.insert( mapsNeedingIDs, map )
         end
     end


### PR DESCRIPTION
Should help with the error:
`- addons/map_vote/lua/mapvote/client/modules/thumb_downloader.lua:106: attempt to call upvalue 'callback' (a nil value)`
as there is no way the two tables can now get desynced while also simplifying the logic to be easier to debug later on